### PR TITLE
fix: sailfish: Add additional .xml files to navit spec.

### DIFF
--- a/contrib/sailfish/navit-sailfish.spec
+++ b/contrib/sailfish/navit-sailfish.spec
@@ -114,6 +114,12 @@ fi
 %files
 %defattr(644, root, root, 755)
 %{_datadir}/harbour-navit/navit.xml
+%{_datadir}/harbour-navit/navit_layout_auto.xml
+%{_datadir}/harbour-navit/navit_layout_bike.xml
+%{_datadir}/harbour-navit/navit_layout_car_android.xml
+%{_datadir}/harbour-navit/navit_layout_car_dark.xml
+%{_datadir}/harbour-navit/navit_layout_car_simple.xml
+%{_datadir}/harbour-navit/navit_layout_th.xml
 %{_datadir}/harbour-navit/icons/
 %{_datadir}/harbour-navit/maps/osm_bbox_11.3,47.9,11.7,48.2.bin
 %{_datadir}/harbour-navit/espeak-data/


### PR DESCRIPTION
Since more configuration files are installed now, we need to add them to
the rpm as well.
